### PR TITLE
Fix for issue #2: Do not rely on allow_url_fopen

### DIFF
--- a/includes/classes.php
+++ b/includes/classes.php
@@ -10,8 +10,12 @@ class BeerXML {
 
 		libxml_disable_entity_loader();
 		libxml_use_internal_errors( true );
-		$xml = file_get_contents( $xml_loc );
-		$xrecipes = simplexml_load_string( $xml );
+        $curl_session = curl_init();
+        curl_setopt($curl_session, CURLOPT_URL, $xml_loc);
+        curl_setopt($curl_session, CURL_RETURNTRANSFER, true);
+        $xml = curl_exec($curl_session);
+        curl_close($curl_session);
+        $xrecipes = simplexml_load_string( $xml );
 		if ( ! $xrecipes )
 			return;
 


### PR DESCRIPTION
This fixes "beerxml-plugin does not work when URL file-access is disabled in the server configuration" issue (https://github.com/dbspringer/beerxml-plugin/issues/2) by replacing the file_get_contents call with cURL.
