### PR TITLE
Added mash and fermentation sections that are optional

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -63,7 +63,9 @@ class BeerXML_Admin {
 		register_setting( 'beerxml_shortcode_group', 'beerxml_shortcode_cache', 'absint' );
 		register_setting( 'beerxml_shortcode_group', 'beerxml_shortcode_download', 'absint' );
 		register_setting( 'beerxml_shortcode_group', 'beerxml_shortcode_style', 'absint' );
-
+		register_setting( 'beerxml_shortcode_group', 'beerxml_shortcode_mash', 'absint' );
+		register_setting( 'beerxml_shortcode_group', 'beerxml_shortcode_fermentation', 'absint' );
+		
 		add_settings_section(
 			'beerxml_shortcode_section',
 			__( 'Shortcode default settings', 'beerxml-shortcode' ),
@@ -99,6 +101,22 @@ class BeerXML_Admin {
 			'beerxml_shortcode_style',
 			__( 'Include style details', 'beerxml-shortcode' ),
 			array( $this, 'style_option' ),
+			'beerxml-shortcode',
+			'beerxml_shortcode_section'
+		);
+		
+		add_settings_field(
+			'beerxml_shortcode_mash',
+			__( 'Include mash details', 'beerxml-shortcode' ),
+			array( $this, 'mash_option' ),
+			'beerxml-shortcode',
+			'beerxml_shortcode_section'
+		);
+		
+		add_settings_field(
+			'beerxml_shortcode_fermentation',
+			__( 'Include fermentation details', 'beerxml-shortcode' ),
+			array( $this, 'fermentation_option' ),
 			'beerxml-shortcode',
 			'beerxml_shortcode_section'
 		);
@@ -148,6 +166,24 @@ class BeerXML_Admin {
 	function style_option() {
 		?>
 		<input type="checkbox" id="beerxml_shortcode_style" name="beerxml_shortcode_style" value="1" <?php checked( get_option( 'beerxml_shortcode_style', 1 ) ); ?> />
+		<?php
+	}
+	
+	/**
+	 * Callback for mash option
+	 */
+	function mash_option() {
+		?>
+		<input type="checkbox" id="beerxml_shortcode_mash" name="beerxml_shortcode_mash" value="1" <?php checked( get_option( 'beerxml_shortcode_mash', 1 ) ); ?> />
+		<?php
+	}
+	
+	/**
+	 * Callback for fermentation option
+	 */
+	function fermentation_option() {
+		?>
+		<input type="checkbox" id="beerxml_shortcode_fermentation" name="beerxml_shortcode_fermentation" value="1" <?php checked( get_option( 'beerxml_shortcode_fermentation', 1 ) ); ?> />
 		<?php
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://wordpressfoundation.org/donate/
 Tags: shortcode, beer, beerxml, homebrew, recipe
 Requires at least: 3.4
 Tested up to: 4.1
-Stable tag: 0.3.2
+Stable tag: 0.3.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,7 +21,7 @@ A shortcode for linking to beer recipes.
 
 It follows the basic format of:
 
-[beerxml recipe={URL} metric=true|false download=true|false style=true|false cache=-1|{seconds to cache}]
+[beerxml recipe={URL} metric=true|false download=true|false style=true|false mash=true|false fermentation=true|false cache=-1|{seconds to cache}]
 
 Please note: metric, download, style, and cache are optional values and have the following defaults:
 
@@ -29,6 +29,8 @@ Please note: metric, download, style, and cache are optional values and have the
 * cache = 12 hours (60 x 60 x 12 seconds), -1 kills the cache and sets value to 0
 * download = true
 * style = true
+* mash = true
+* fermentation = true
 
 == Installation ==
 
@@ -42,6 +44,11 @@ Please note: metric, download, style, and cache are optional values and have the
 2. Inserting the shortcode into a post.
 
 == Changelog ==
+
+= 0.3.3 =
+
+* Added Mash Details Section
+* Added Fermentaion Details Section
 
 = 0.3.2 =
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -9,6 +9,8 @@ if ( ! is_multisite() ) {
 	delete_option( 'beerxml_shortcode_units' );
 	delete_option( 'beerxml_shortcode_download' );
 	delete_option( 'beerxml_shortcode_style' );
+	delete_option( 'beerxml_shortcode_mash' );
+	delete_option( 'beerxml_shortcode_fermentation' );
 } else {
 	global $wpdb;
 	$blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
@@ -19,6 +21,8 @@ if ( ! is_multisite() ) {
 		delete_option( 'beerxml_shortcode_units' );
 		delete_option( 'beerxml_shortcode_download' );
 		delete_option( 'beerxml_shortcode_style' );
+		delete_option( 'beerxml_shortcode_mash' );
+		delete_option( 'beerxml_shortcode_fermentation' );
 	}
 
 	switch_to_blog( $original_blog_id );


### PR DESCRIPTION
I have added sections for both mash details and fermentation details.  They are fairly basic and only show a few things.
![capture](https://cloud.githubusercontent.com/assets/4691887/5858341/6b0f23b4-a220-11e4-8b2b-9832c0620f8a.PNG)

I think I did discover a bug in the way BeerSmith exports its BeerXML file though.  If you look at the screen shot the value for Tertiary Temp is 32F but it's using that as the default because BeerSmith isn't including the TERTIARY_TEMP in the export.  They do include DISPLAY_TERTIARY_TEMP but I didn't want to use the display fields as you didn't really use them anywhere else and its kind of not the purpose for them.

I've contacted BeerSmith already asking them to fix the bug and when they do, this should work as well. For now it works fine on 1 and 2 stage fermentation profiles.