### PR TITLE
SSRF hardening / yeast parsing fix

### DIFF
--- a/includes/classes.php
+++ b/includes/classes.php
@@ -5,7 +5,7 @@ class BeerXML {
 	public $recipes = array();
 
 	function __construct( $xml_loc ) {
-		$response = wp_remote_get( $xml_loc );
+		$response = wp_safe_remote_get( $xml_loc );
 		if ( is_wp_error( $response ) ) {
 			$error_message = $response->get_error_message();
 			echo "XML not retrieved: $error_message";
@@ -21,8 +21,9 @@ class BeerXML {
 		libxml_use_internal_errors( true );
 		$xml = wp_remote_retrieve_body( $response );
 		$xrecipes = simplexml_load_string( $xml );
-		if ( ! $xrecipes )
+		if ( ! $xrecipes ) {
 			return;
+		}
 
 		foreach ( $xrecipes->RECIPE as $recipe ) {
 			$this->recipes[] = new BeerXML_Recipe( $recipe );

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: derekspringer, zarathos
 Donate link: http://wordpressfoundation.org/donate/
 Tags: shortcode, beer, beerxml, homebrew, recipe
 Requires at least: 3.4
-Tested up to: 4.9
-Stable tag: 0.7.1
+Tested up to: 6.8
+Stable tag: 0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -59,6 +59,11 @@ Please note all options (minus recipe) are optional and have the following defau
 4. Insert Post Element details.
 
 == Changelog ==
+
+= 0.8 =
+
+* Some potential SSRF fixes.
+* Better error handling for yeasts that don't parse cleanly.
 
 = 0.7.1 =
 


### PR DESCRIPTION
I remain unconvinced the vulnerability notice I received is viable, but I've updated the XML fetching to use [`wp_safe_remote_get`](https://developer.wordpress.org/reference/functions/wp_safe_remote_get/) instead. See: https://github.com/dbspringer/beerxml-plugin/pull/9/files#diff-ded9994ac3d36cc44921b153936abe2fb433f3c37ae14baaf56d40ae057a7d62L7

Plus an update to fix bad yeast values failing parse.